### PR TITLE
Change lombok download URL

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -26,7 +26,7 @@ from LSP.plugin.core.views import text_document_identifier
 
 
 DOWNLOAD_URL = "http://download.eclipse.org/jdtls/snapshots"
-LOMBOK_URL = "https://projectlombok.org/downloads/lombok.jar"
+LOMBOK_URL = "https://repo1.maven.org/maven2/org/projectlombok/lombok/1.18.24/lombok-1.18.24.jar"
 DEFAULT_VERSION = "1.14.0-202207211651"
 SETTINGS_FILENAME = "LSP-jdtls.sublime-settings"
 STORAGE_DIR = 'LSP-jdtls'


### PR DESCRIPTION
Download project lombok jar from maven central instead of project lombok's own site.
Project lombok site blocks requests from python's urllib.requests http client.
Fixes https://github.com/sublimelsp/LSP-jdtls/issues/25

Maven central was chosen as they are a software distribution site so I expect downloads to work reasonably well.

Note this also pins the version of project lombok used. A further improvement could allow some user preference to override the selected version, as is done for jdtls server version.