### PR TITLE
Adapt to API changes in LSP 1.28.0

### DIFF
--- a/modules/jdtls.py
+++ b/modules/jdtls.py
@@ -12,7 +12,7 @@ from LSP.plugin import (
     unregister_plugin,
 )
 from LSP.plugin.core.protocol import DocumentUri
-from LSP.plugin.core.sessions import ExecuteCommandParams
+from LSP.plugin.core.protocol import ExecuteCommandParams
 from LSP.plugin.core.types import ClientConfig
 from LSP.plugin.core.typing import Any, Callable, Dict, List, Optional
 from LSP.plugin.core.views import text_document_identifier
@@ -228,14 +228,14 @@ class EclipseJavaDevelopmentTools(AbstractPlugin):
     #########################
 
     def on_pre_server_command(
-        self, command: ExecuteCommandParams, done: Callable[[], None]
+        self, command: ExecuteCommandParams, done_callback: Callable[[], None]
     ) -> bool:
         session = self.weaksession()
         if not session:
             return False
         if handle_client_command(
             session,
-            done,
+            done_callback,
             command["command"],
             command["arguments"] if "arguments" in command else [],
         ):

--- a/modules/protocol_extensions_handler.py
+++ b/modules/protocol_extensions_handler.py
@@ -4,11 +4,11 @@ Handler for JDTLS protocol extensions.
 See https://github.com/redhat-developer/vscode-java/blob/master/src/standardLanguageClient.ts
 """
 import sublime
+from LSP.plugin import Session
 from LSP.plugin.core.protocol import (
     Command,
     ExecuteCommandParams,  # noqa: F401
 )
-from LSP.plugin.core.sessions import Session
 from LSP.plugin.core.typing import Optional
 
 from .protocol import ActionableNotification, ProgressReport, StatusReport

--- a/modules/test_extension_commands.py
+++ b/modules/test_extension_commands.py
@@ -4,8 +4,8 @@ import os
 import sublime
 from LSP.plugin import Session, parse_uri
 from LSP.plugin.core.constants import KIND_CLASS, KIND_METHOD
-from LSP.plugin.core.edit import WorkspaceEdit, parse_workspace_edit
 from LSP.plugin.core.protocol import ExecuteCommandParams  # noqa: F401
+from LSP.plugin.core.protocol import WorkspaceEdit
 from LSP.plugin.core.typing import Callable, List, Tuple
 from LSP.plugin.core.views import (
     first_selection_region,
@@ -52,17 +52,8 @@ class LspJdtlsGenerateTests(LspJdtlsTextCommand):
                 print(workspace_edit)
                 return
 
-            parsed_worspace_edit = parse_workspace_edit(workspace_edit)
-
-            def open_changed_file(result):
-                window = self.view.window()
-                if window and parsed_worspace_edit:
-                    for uri in parsed_worspace_edit:
-                        open_and_focus_uri(window, uri)
-                        return
-
-            session.apply_parsed_workspace_edits(parsed_worspace_edit).then(
-                open_changed_file
+            sublime.set_timeout_async(
+                lambda: session.apply_workspace_edit_async(workspace_edit)
             )
 
         session.execute_command(command, False).then(_on_done)

--- a/modules/test_extension_commands.py
+++ b/modules/test_extension_commands.py
@@ -2,7 +2,7 @@ import json
 import os
 
 import sublime
-from LSP.plugin import Session, parse_uri
+from LSP.plugin import Session, parse_uri, uri_from_view
 from LSP.plugin.core.constants import KIND_CLASS, KIND_METHOD
 from LSP.plugin.core.protocol import ExecuteCommandParams  # noqa: F401
 from LSP.plugin.core.protocol import WorkspaceEdit
@@ -10,7 +10,6 @@ from LSP.plugin.core.typing import Callable, List, Tuple
 from LSP.plugin.core.views import (
     first_selection_region,
     offset_to_point,
-    uri_from_view,
 )
 
 from .constants import SESSION_NAME

--- a/modules/workspace_execute_command_handler.py
+++ b/modules/workspace_execute_command_handler.py
@@ -2,7 +2,6 @@
 
 import sublime
 from LSP.plugin import Session
-from LSP.plugin.core.edit import apply_workspace_edit, parse_workspace_edit
 from LSP.plugin.core.types import Callable
 from LSP.plugin.core.views import location_to_encoded_filename
 
@@ -43,12 +42,9 @@ def _set_null_analysis_mode(
 
 
 def _apply_workspace_edit(session: Session, done: Callable[[], None], *arguments):
-    changes = parse_workspace_edit(arguments[0])
-    window = session.window
-    sublime.set_timeout(
-        lambda: apply_workspace_edit(window, changes).then(
-            lambda _: sublime.set_timeout_async(done)
-        )
+    changes = arguments[0]
+    sublime.set_timeout_async(
+        lambda: session.apply_workspace_edit_async(changes).then(lambda _: done())
     )
 
 

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -520,7 +520,9 @@
                             "Do not show any build status on start"
                           ]
                         },
-                        "boolean"
+                        {
+                          "type": "boolean"
+                        }
                       ],
                       "description": "Automatically show build status on startup.",
                       "default": "notification",


### PR DESCRIPTION
Adapt to changes (https://github.com/sublimelsp/LSP/pull/2393) in (yet to be released at the time of writing this) LSP 1.28.0.

Mainly updates the code that applies text edits plus some minor import changes to avoid "private" exports.

> [!WARNING]
> The changes need to be released at the same time as the new version of LSP

Resolves #46 (Haven't verified behavior before and after. Not sure if there are some minor behavior changes)