### PR TITLE
Update method for printing progress to the status bar

### DIFF
--- a/modules/protocol_extensions_handler.py
+++ b/modules/protocol_extensions_handler.py
@@ -52,23 +52,20 @@ def language_actionableNotification(
     run_command(command)
 
 
+progress_reports = dict()  # type: dict[str, str]
+
+
 def language_progressReport(session: Session, params: ProgressReport):
     key = params["id"] if "id" in params else "jdtls-status-dummy-key"
-    if not params["complete"]:
-        session.set_window_status_async(
-            key,
-            "{}% {}".format(
-                params["workDone"] / params["totalWork"] * 100, params["task"]
-            ),
-        )
-    else:
-        session.set_window_status_async(
-            key,
-            "{}% {}".format(
-                params["totalWork"] / params["totalWork"] * 100, params["task"]
-            ),
-        )
-        sublime.set_timeout_async(lambda: session.erase_window_status_async(key), 1000)
+    progress_reports[key] = "{}% {}".format(params["workDone"] / params["totalWork"] * 100, params["task"])
+    _update_config_status_async(session)
+    if params["complete"]:
+        progress_reports.pop(key, None)
+        sublime.set_timeout_async(lambda: _update_config_status_async(session), 1000)
+
+
+def _update_config_status_async(session: Session) -> None:
+    session.set_config_status_async(", ".join(progress_reports.values()))
 
 
 def language_status(session: Session, params: StatusReport) -> None:


### PR DESCRIPTION
I'd like to deprecate the `Session.set_window_status_async` method in LSP, because there is also the newer `Session.set_config_status_async` which does basically the same thing.

The only change from this PR should be that the progress reports from `language/progressReport` notifications will be shown in brackets directly after the server name in the status bar.

Note that I have not tested this explicitly, because I couldn't figure out how to make this server emit `language/progressReport` notifications (it seems to use a lot of regular `$/progress` notifications though, which are handled directly by LSP).
