### PR TITLE
Replace no longer available get_storage_path

### DIFF
--- a/modules/installer.py
+++ b/modules/installer.py
@@ -8,8 +8,8 @@ from urllib.request import urlopen
 from pathlib import Path
 
 import sublime
+from LSP.plugin import AbstractPlugin
 from LSP.plugin.core.typing import Callable, Union
-from LSP.plugin.core.views import get_storage_path
 
 from .constants import (
     DATA_DIR,
@@ -96,7 +96,7 @@ def extract_tar(url: str, path: str):
 
 
 def storage_subpath() -> str:
-    return os.path.join(get_storage_path(), STORAGE_DIR)
+    return os.path.join(AbstractPlugin.storage_path(), STORAGE_DIR)
 
 
 def install_path() -> str:


### PR DESCRIPTION
This commit replaces no longer existing internal function `get_storage_path()` by API compliant counterpart.

caused by: https://github.com/sublimelsp/LSP/pull/2614