### PR TITLE
The server requires JDK 21 instead of 17

### DIFF
--- a/LSP-jdtls.sublime-settings
+++ b/LSP-jdtls.sublime-settings
@@ -48,7 +48,7 @@
     "test.filterStacktrace": true,
     // The server-specific settings.
     "settings": {
-        // Specifies the folder path to the JDK (17 or more recent) used to launch the Java Language Server.
+        // Specifies the folder path to the JDK (21 or more recent) used to launch the Java Language Server.
         "java.jdt.ls.java.home": null,
         // Enable/disable the 'auto build'
         "java.autobuild.enabled": true,

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -19,7 +19,7 @@
                         "null"
                       ],
                       "default": null,
-                      "description": "Specifies the folder path to the JDK (17 or more recent) used to launch the Java Language Server.\nOn Windows, backslashes must be escaped, i.e.\n\"java.home\":\"C:\\\\Program Files\\\\Java\\\\jdk-17.0_3\"",
+                      "description": "Specifies the folder path to the JDK (21 or more recent) used to launch the Java Language Server.\nOn Windows, backslashes must be escaped, i.e.\n\"java.home\":\"C:\\\\Program Files\\\\Java\\\\jdk-21.0_7\"",
                       "scope": "machine-overridable",
                       "deprecationMessage": "This setting is deprecated, please use 'java.jdt.ls.java.home' instead."
                     },
@@ -29,7 +29,7 @@
                         "null"
                       ],
                       "default": null,
-                      "description": "Specifies the folder path to the JDK (17 or more recent) used to launch the Java Language Server. This setting will replace the Java extension's embedded JRE to start the Java Language Server. \n\nOn Windows, backslashes must be escaped, i.e.\n\"java.jdt.ls.java.home\":\"C:\\\\Program Files\\\\Java\\\\jdk-17.0_3\"",
+                      "description": "Specifies the folder path to the JDK (21 or more recent) used to launch the Java Language Server. This setting will replace the Java extension's embedded JRE to start the Java Language Server. \n\nOn Windows, backslashes must be escaped, i.e.\n\"java.jdt.ls.java.home\":\"C:\\\\Program Files\\\\Java\\\\jdk-21.0_7\"",
                       "scope": "machine-overridable"
                     },
                     "java.errors.incompleteClasspath.severity": {


### PR DESCRIPTION
jdtls requires JDK 21, instead of 17.

The REAMDE was already updated in the past with that info:
> To use this package, you must have:
> - The [LSP](https://packagecontrol.io/packages/LSP) package.
> - A Java SDK (>= 21).

but some places were skipped by accident.

In this PR I just updated more places to reflect that requirement.

