### PR TITLE
refactor: add import formatting and linting rules

### DIFF
--- a/LSP-jdtls.sublime-settings
+++ b/LSP-jdtls.sublime-settings
@@ -37,7 +37,6 @@
         "-data",
         "${datadir}"
     ],
-    "initializationOptions": {},
     // Overwrite the jdtls version. An empty string uses the latest release that was tested by the LSP-jdtls developers. 
     // Must be formatted like "1.27.1" matching https://download.eclipse.org/jdtls/milestones/.
     // Restart sublime after changing this setting

--- a/boot.py
+++ b/boot.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 def reload_plugin() -> None:
     import sys
+
     for m in list(sys.modules.keys()):
         if m.startswith(str(__package__) + ".") and m != __name__:
             del sys.modules[m]

--- a/boot.py
+++ b/boot.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 def reload_plugin() -> None:
     import sys
-
     for m in list(sys.modules.keys()):
         if m.startswith(str(__package__) + ".") and m != __name__:
             del sys.modules[m]
@@ -11,4 +10,4 @@ def reload_plugin() -> None:
 
 reload_plugin()
 
-from .modules import *  # noqa: E402, F403
+from .modules import *

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -13,18 +13,16 @@ from .test_extension_commands import (
 )
 
 __all__ = (
-    # LSP adapter
-    "plugin_loaded",
-    "plugin_unloaded",
     "EclipseJavaDevelopmentTools",
-    # Sublime commands
-    "LspJdtlsRefreshWorkspace",
+    "JdtlsClearData",
     "JdtlsInputCommand",
+    "LspJdtlsBuildWorkspace",
     "LspJdtlsGenerateTests",
     "LspJdtlsGotoTest",
+    "LspJdtlsRefreshWorkspace",
+    "LspJdtlsRunTest",
     "LspJdtlsRunTestAtCursor",
     "LspJdtlsRunTestClass",
-    "LspJdtlsRunTest",
-    "LspJdtlsBuildWorkspace",
-    "JdtlsClearData",
+    "plugin_loaded",
+    "plugin_unloaded",
 )

--- a/modules/debug_extension.py
+++ b/modules/debug_extension.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from typing_extensions import override
 
 from LSP.plugin import Notification, Session
 from LSP.plugin.core.protocol import Error
 from LSP.protocol import ExecuteCommandParams, TextDocumentIdentifier
+from typing_extensions import override
 
 from .utils import LspJdtlsTextCommand
 

--- a/modules/installer.py
+++ b/modules/installer.py
@@ -6,9 +6,9 @@ import stat
 import tarfile
 import tempfile
 import zipfile
-from urllib.request import urlopen
 from pathlib import Path
 from typing import Callable
+from urllib.request import urlopen
 
 import sublime
 from LSP.plugin.core.constants import ST_STORAGE_PATH

--- a/modules/jdtls.py
+++ b/modules/jdtls.py
@@ -3,11 +3,10 @@ from __future__ import annotations
 import json
 import os
 import re
-from typing import Any, Callable, TYPE_CHECKING
-from typing_extensions import override
+from typing import TYPE_CHECKING, Any, Callable
+from urllib.parse import urlparse
 
 import sublime
-from urllib.parse import urlparse
 from LSP.plugin import (
     AbstractPlugin,
     Request,
@@ -17,6 +16,7 @@ from LSP.plugin import (
 )
 from LSP.plugin.core.views import text_document_identifier
 from LSP.protocol import TextDocumentIdentifier
+from typing_extensions import override
 
 from . import installer
 from .constants import (

--- a/modules/protocol.py
+++ b/modules/protocol.py
@@ -7,9 +7,9 @@ https://github.com/redhat-developer/vscode-java/blob/master/src/protocol.ts
 from __future__ import annotations
 
 from enum import IntEnum
-from typing import Any, TypedDict, TYPE_CHECKING
-from typing_extensions import NotRequired
+from typing import TYPE_CHECKING, Any, TypedDict
 
+from typing_extensions import NotRequired
 
 if TYPE_CHECKING:
     from LSP.protocol import Command, MessageType

--- a/modules/protocol_extensions_handler.py
+++ b/modules/protocol_extensions_handler.py
@@ -7,14 +7,16 @@ See https://github.com/redhat-developer/vscode-java/blob/master/src/standardLang
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+
 import sublime
 
 from .quick_input_panel import QuickSelect, SelectableItem
 
 if TYPE_CHECKING:
-    from .protocol import ActionableNotification, ProgressReport, StatusReport
     from LSP.plugin import Session
     from LSP.protocol import Command, ExecuteCommandParams
+
+    from .protocol import ActionableNotification, ProgressReport, StatusReport
 
 
 def language_actionableNotification(

--- a/modules/quick_input_panel.py
+++ b/modules/quick_input_panel.py
@@ -12,11 +12,12 @@ Inspired by https://github.com/daveleroy/sublime_debugger/blob/master/modules/ui
 from __future__ import annotations
 
 from typing import Any, Callable, final
-from typing_extensions import override
 
 import sublime
 import sublime_plugin
-from LSP.plugin.core.promise import Promise, PackagedTask
+from LSP.plugin import Promise
+from LSP.plugin.core.promise import PackagedTask
+from typing_extensions import override
 
 
 @final

--- a/modules/test_extension_commands.py
+++ b/modules/test_extension_commands.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 import json
 import os
-from typing import Callable, TYPE_CHECKING
-from typing_extensions import override
+from typing import TYPE_CHECKING, Callable
 
 import sublime
 from LSP.plugin import Session, parse_uri, uri_from_view
@@ -11,6 +10,7 @@ from LSP.plugin.core.constants import KIND_CLASS, KIND_METHOD
 from LSP.plugin.core.edit import WorkspaceEditSummary, parse_workspace_edit
 from LSP.plugin.core.protocol import Error
 from LSP.plugin.core.views import first_selection_region, offset_to_point
+from typing_extensions import override
 
 from .constants import SESSION_NAME
 from .installer import vscode_plugin_path
@@ -186,9 +186,7 @@ class LspJdtlsTestCommand(LspJdtlsTextCommand):
         )
 
     def get_test_name(self, test_item: IJavaTestItem) -> str:
-        if test_item["testKind"] == TestKind.TestNG:
-            return test_item["fullName"]
-        elif test_item["testLevel"] == TestLevel.Class:
+        if test_item["testKind"] == TestKind.TestNG or test_item["testLevel"] == TestLevel.Class:
             return test_item["fullName"]
         else:
             return test_item["jdtHandler"]

--- a/modules/test_extension_server.py
+++ b/modules/test_extension_server.py
@@ -7,9 +7,9 @@ import threading
 from datetime import datetime, timedelta
 from enum import Enum
 from typing import Literal, TypedDict, cast, final
-from typing_extensions import NotRequired, override
 
 import sublime
+from typing_extensions import NotRequired, override
 
 from .utils import filter_lines, get_settings
 
@@ -451,11 +451,7 @@ class _JunitResultsHandler(_TestResultsHandler):
                     + "\n"
                 )
 
-        elif header == EclipseTestRunnerMessageIds.TEST_FAILED:
-            self.current_test = container.get_by_id(int(args[0]))
-            if self.current_test:
-                self.current_test.set_failed()
-        elif header == EclipseTestRunnerMessageIds.TEST_ERROR:
+        elif header in {EclipseTestRunnerMessageIds.TEST_FAILED, EclipseTestRunnerMessageIds.TEST_ERROR}:
             self.current_test = container.get_by_id(int(args[0]))
             if self.current_test:
                 self.current_test.set_failed()
@@ -473,11 +469,7 @@ class _JunitResultsHandler(_TestResultsHandler):
             self.line_consumer = self.current_test.append_actual
         elif header == EclipseTestRunnerMessageIds.EXPECTED_START and self.current_test:
             self.line_consumer = self.current_test.append_expected
-        elif header == EclipseTestRunnerMessageIds.TRACE_END:
-            self.line_consumer = None
-        elif header == EclipseTestRunnerMessageIds.ACTUAL_END:
-            self.line_consumer = None
-        elif header == EclipseTestRunnerMessageIds.EXPECTED_END:
+        elif header in {EclipseTestRunnerMessageIds.TRACE_END, EclipseTestRunnerMessageIds.ACTUAL_END, EclipseTestRunnerMessageIds.EXPECTED_END}:
             self.line_consumer = None
         elif header == EclipseTestRunnerMessageIds.TEST_RUN_END:
             # runtime_ms = int(args[0])

--- a/modules/text_extension_protocol.py
+++ b/modules/text_extension_protocol.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from enum import IntEnum
-from typing import TypedDict, TYPE_CHECKING
+from typing import TYPE_CHECKING, TypedDict
+
 from typing_extensions import NotRequired
 
 if TYPE_CHECKING:

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-from typing import Any, Callable, TYPE_CHECKING
-from typing_extensions import override
+from typing import TYPE_CHECKING, Any, Callable
 
 import sublime
-
 from LSP.plugin import AbstractPlugin, LspTextCommand, Session, parse_uri
+from typing_extensions import override
 
 from .constants import SESSION_NAME, SETTINGS_FILENAME
 

--- a/modules/workspace_execute_command_handler.py
+++ b/modules/workspace_execute_command_handler.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Callable, TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable
 
 import sublime
 from LSP.plugin.core.views import location_to_encoded_filename

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,6 @@
 [tool.pyright]
 pythonVersion = '3.8'
-reportAny = "none"
-reportExplicitAny = "none"
-reportImplicitOverride = "none"
-reportIncompatibleMethodOverride = "none"
-reportMissingModuleSource = "none"
-reportUnannotatedClassAttribute = "none"
-reportUnknownArgumentType = "none"
-reportUnknownMemberType = "none"
-reportUnknownVariableType = "none"
-reportUnusedCallResult = "none"
+typeCheckingMode = "standard"
 
 [tool.ruff]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,28 @@
+[tool.pyright]
+pythonVersion = '3.8'
+reportAny = "none"
+reportExplicitAny = "none"
+reportImplicitOverride = "none"
+reportIncompatibleMethodOverride = "none"
+reportMissingModuleSource = "none"
+reportUnannotatedClassAttribute = "none"
+reportUnknownArgumentType = "none"
+reportUnknownMemberType = "none"
+reportUnknownVariableType = "none"
+reportUnusedCallResult = "none"
+
+[tool.ruff]
+line-length = 120
+target-version = 'py38'
+
+[tool.ruff.format]
+quote-style = "preserve"
+indent-style = "space"
+# Respect magic trailing commas.
+skip-magic-trailing-comma = false
+# Automatically detect the appropriate line ending.
+line-ending = "auto"
+
+[tool.ruff.lint.isort]
+case-sensitive = false
+required-imports = ["from __future__ import annotations"]


### PR DESCRIPTION
Ensure imports formatting is consistent for everybody by adding ruff rules that match existing style. Ideally we'd switch to the same style as used in LSP but I don't want to force anything on others.